### PR TITLE
add ability to override default converter for field

### DIFF
--- a/src/main/java/ru/qatools/properties/annotations/Use.java
+++ b/src/main/java/ru/qatools/properties/annotations/Use.java
@@ -1,0 +1,20 @@
+package ru.qatools.properties.annotations;
+
+import org.apache.commons.beanutils.Converter;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Using this annotation you can override default converter
+ * for property.
+ *
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 05.05.15
+ */
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target({java.lang.annotation.ElementType.FIELD})
+public @interface Use {
+
+    Class<? extends Converter> value();
+}

--- a/src/test/java/ru/qatools/properties/CustomConverterTest.java
+++ b/src/test/java/ru/qatools/properties/CustomConverterTest.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 import ru.qatools.properties.testdata.PropertiesWithCustomConverter;
 import ru.qatools.properties.testdata.UpperCaseStringConverter;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -16,14 +18,17 @@ import static org.junit.Assert.assertThat;
  */
 public class CustomConverterTest {
 
-    private static final String VALUE = "value";
+    private static final String VALUE_FOR_FIELD = "value";
+
+    private static final String VALUE_FOR_FIELD_WITH_USE = "first, second";
 
     private PropertiesWithCustomConverter properties;
 
     @Before
     public void initProperties() {
         Properties override = new Properties();
-        override.setProperty("field", VALUE);
+        override.setProperty("field", VALUE_FOR_FIELD);
+        override.setProperty("field.with.use.annotation", VALUE_FOR_FIELD_WITH_USE);
 
         properties = new PropertiesWithCustomConverter();
         PropertyLoader.newInstance()
@@ -33,7 +38,13 @@ public class CustomConverterTest {
     }
 
     @Test
-    public void testOutput() {
-        assertThat(properties.field, equalTo(VALUE.toUpperCase()));
+    public void testFieldWithOverriddenDefaultConverter() {
+        assertThat(properties.field, equalTo(VALUE_FOR_FIELD.toUpperCase()));
+    }
+
+    @Test
+    public void testFieldWithOverriddenConverterInUseAnnotation() {
+        List<String> expected = Arrays.asList(VALUE_FOR_FIELD_WITH_USE.split(", "));
+        assertThat(properties.fieldWithUseAnnotation, equalTo(expected));
     }
 }

--- a/src/test/java/ru/qatools/properties/testdata/CommaSeparatedStringConverter.java
+++ b/src/test/java/ru/qatools/properties/testdata/CommaSeparatedStringConverter.java
@@ -1,0 +1,22 @@
+package ru.qatools.properties.testdata;
+
+import org.apache.commons.beanutils.converters.AbstractConverter;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 05.05.15
+ */
+public class CommaSeparatedStringConverter extends AbstractConverter {
+    @Override
+    protected <T> T convertToType(Class<T> type, Object value) throws Throwable {
+        return type.cast(Arrays.asList(value.toString().split(", ")));
+    }
+
+    @Override
+    protected Class<?> getDefaultType() {
+        return List.class;
+    }
+}

--- a/src/test/java/ru/qatools/properties/testdata/PropertiesWithCustomConverter.java
+++ b/src/test/java/ru/qatools/properties/testdata/PropertiesWithCustomConverter.java
@@ -1,6 +1,9 @@
 package ru.qatools.properties.testdata;
 
 import ru.qatools.properties.annotations.Property;
+import ru.qatools.properties.annotations.Use;
+
+import java.util.List;
 
 /**
  * @author Artem Eroshenko eroshenkoam
@@ -10,4 +13,8 @@ public class PropertiesWithCustomConverter {
 
     @Property("field")
     public String field;
+
+    @Use(CommaSeparatedStringConverter.class)
+    @Property("field.with.use.annotation")
+    public List<String> fieldWithUseAnnotation;
 }


### PR DESCRIPTION
Recover  `@Use` annotation. It can be used to specify custom converter for field. An example - split some comma-separated string to list.