### PR TITLE
Add required annotation support

### DIFF
--- a/src/main/java/ru/qatools/properties/PropertyLoader.java
+++ b/src/main/java/ru/qatools/properties/PropertyLoader.java
@@ -151,6 +151,7 @@ public class PropertyLoader {
                 String stringValue = compiled.getProperty(key, defaultValue);
 
                 if (stringValue == null) {
+                    checkRequired(key, element);
                     continue;
                 }
 
@@ -190,6 +191,25 @@ public class PropertyLoader {
      */
     protected boolean shouldDecorate(AnnotatedElement element) {
         return element.isAnnotationPresent(Property.class);
+    }
+
+    /**
+     * Throws an exception if given element is required.
+     *
+     * @see #isRequired(AnnotatedElement)
+     */
+    protected void checkRequired(String key, AnnotatedElement element) {
+        if (isRequired(element)) {
+            throw new PropertyLoaderException(String.format("Required property " +
+                    "<%s> for element <%s> doesn't exists", key, element));
+        }
+    }
+
+    /**
+     * Returns true if annotatedElement marked as required with {@link Required}.
+     */
+    protected boolean isRequired(AnnotatedElement element) {
+        return element.isAnnotationPresent(Required.class);
     }
 
     /**

--- a/src/main/java/ru/qatools/properties/Required.java
+++ b/src/main/java/ru/qatools/properties/Required.java
@@ -1,0 +1,14 @@
+package ru.qatools.properties;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 03.06.15
+ */
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+public @interface Required {
+}

--- a/src/test/java/ru/qatools/properties/RequiredPropertyTest.java
+++ b/src/test/java/ru/qatools/properties/RequiredPropertyTest.java
@@ -1,0 +1,38 @@
+package ru.qatools.properties;
+
+import org.junit.Test;
+import ru.qatools.properties.testdata.ProxyPropertiesFactory;
+
+/**
+ * @author Dmitry Baev charlie@yandex-team.ru
+ *         Date: 03.06.15
+ */
+public class RequiredPropertyTest {
+
+    @Test(expected = PropertyLoaderException.class)
+    public void shouldThrowAnExceptionIfRequiredDoesNotExists() throws Exception {
+        new PropertyLoader().populate(MyFirstConfig.class);
+    }
+
+    @Test
+    public void shouldNotThrowAnExceptionIfRequiredExists() throws Exception {
+        new PropertyLoader().populate(MySecondConfig.class);
+    }
+
+    public interface MyFirstConfig {
+
+        @Required
+        @Property("proxy.host")
+        String getHost();
+
+    }
+
+    @Resource.Classpath(ProxyPropertiesFactory.RESOURCE_PATH)
+    public interface MySecondConfig {
+
+        @Required
+        @Property("proxy.host")
+        String getHost();
+
+    }
+}


### PR DESCRIPTION
Throw an exception if property marked with `@Required` annotation can't be resolved. 

```java
@Resource.Classpath("proxy.properties")
public interface MyConfig {

    @Property("proxy.port")
    int getPort();

    @Required
    @Property("proxy.host")
    String getHost();

}
```