### PR TITLE
allow to redefine enum converter with register

### DIFF
--- a/src/main/java/ru/qatools/properties/converters/ConverterManager.java
+++ b/src/main/java/ru/qatools/properties/converters/ConverterManager.java
@@ -94,19 +94,19 @@ public class ConverterManager {
      * Find converter for given type. Returns null if converter doesn't exists.
      */
     protected <T> Converter<T> find(Class<T> type) throws ConversionException {
-        if (type.isEnum()) {
-            //noinspection unchecked
-            return new EnumConverter((Class<? extends Enum>) type);
-        }
-        if (type.isArray()) {
-            Class<?> componentType = type.getComponentType();
-            Converter childConverter = find(componentType);
-            //noinspection unchecked
-            return new ArrayConverter(childConverter, componentType, stringSplitter);
-        }
         //noinspection unchecked
         Converter<T> converter = (Converter<T>) storage.get(type);
         if (converter == null) {
+            if (type.isEnum()) {
+                //noinspection unchecked
+                return new EnumConverter((Class<? extends Enum>) type);
+            }
+            if (type.isArray()) {
+                Class<?> componentType = type.getComponentType();
+                Converter childConverter = find(componentType);
+                //noinspection unchecked
+                return new ArrayConverter(childConverter, componentType, stringSplitter);
+            }
             throw new ConversionException(String.format("Could not find converter for type <%s>", type));
         }
         return converter;

--- a/src/test/java/ru/qatools/properties/converters/CustomEnumConverterTest.java
+++ b/src/test/java/ru/qatools/properties/converters/CustomEnumConverterTest.java
@@ -1,0 +1,60 @@
+package ru.qatools.properties.converters;
+
+import org.junit.Test;
+import ru.qatools.properties.DefaultValue;
+import ru.qatools.properties.Property;
+import ru.qatools.properties.PropertyLoader;
+import ru.qatools.properties.Use;
+import ru.qatools.properties.testdata.PropEnum;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public class CustomEnumConverterTest {
+
+    @Test
+    public void shouldUseRegisteredConverterForEnum() throws Exception {
+        PropEnum value = PropertyLoader.newInstance()
+                .register(new AlwaysGondorEnumConverter(), PropEnum.class)
+                .populate(Props.class).getValue();
+
+        assertThat("always gondor enum converter", value, is(PropEnum.GONDOR));
+    }
+
+    @Test
+    public void shouldUseRegisteredInAnnotationConverterForEnum() throws Exception {
+        PropEnum value = PropertyLoader.newInstance()
+                .register(new AlwaysMordorEnumConverter(), PropEnum.class)
+                .populate(Props.class).getAnnotatedValue();
+
+        assertThat("always gondor enum converter win", value, is(PropEnum.GONDOR));
+    }
+
+    public interface Props {
+        @Property("prop")
+        @DefaultValue("unkn")
+        PropEnum getValue();    
+        
+        @Property("prop")
+        @DefaultValue("unkn")
+        @Use(AlwaysGondorEnumConverter.class)
+        PropEnum getAnnotatedValue();
+    }
+
+    public static class AlwaysGondorEnumConverter implements Converter<PropEnum> {
+        @Override
+        public PropEnum convert(String from) throws Exception {
+            return PropEnum.GONDOR;
+        }
+    }
+
+    public static class AlwaysMordorEnumConverter implements Converter<PropEnum> {
+        @Override
+        public PropEnum convert(String from) throws Exception {
+            return PropEnum.MORDOR;
+        }
+    }
+}


### PR DESCRIPTION
Can be useful with lambdas in java8 in register method. (No need to define separate converter class)
<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/qatools/properties/40)
<!-- Reviewable:end -->
