### PR TITLE
Use field classLoader to create Proxy

### DIFF
--- a/src/main/java/ru/qatools/properties/PropertyLoader.java
+++ b/src/main/java/ru/qatools/properties/PropertyLoader.java
@@ -90,7 +90,7 @@ public class PropertyLoader {
         checkConfigurationClass(clazz);
         Map<Method, PropertyInfo> properties = resolve(prefix, clazz.getMethods(), resolvedConfigs);
         //noinspection unchecked
-        return (T) Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{clazz},
+        return (T) Proxy.newProxyInstance(classLoader, new Class[]{clazz},
                 new PropertiesProxy(properties));
     }
 


### PR DESCRIPTION
Sample usage: 
```java
PropertyLoader.newInstance().populate(PluginProperties.class);
```
In case `PluginProperties` interface was loaded by different class loader code will throw `java.lang.IllegalArgumentException: interface com.***.PluginProperties is not visible from class loader` exception.

To fix this it is advised to use 
```
PropertyLoader.withClassLoader(PluginProperties.class.getClassLoader())
``` 
method. The problem is that `PropertyLoader.classLoader` field is ignored during proxy creation. This pull request fixes the issue.